### PR TITLE
Patch for Draftable Trait compatibility with Soda Blog module

### DIFF
--- a/src/Database/ContentServiceProvider.php
+++ b/src/Database/ContentServiceProvider.php
@@ -94,7 +94,7 @@ class ContentServiceProvider extends ServiceProvider
         $this->registerAliases($this->aliases);
 
         if ( config('soda.cms.enable_publish_date') ) {
-            Content::$publishDateField = 'published_at';
+            Content::setPublishDateField('published_at');
         }
     }
 


### PR DESCRIPTION
Please pull this into a development branch and test on a project with Soda Blog before merging.

The goal is to match the previous functionality of the Blog Post "publishedAtField" functionality, by changing the property definition to a protected string. This also required a setter function for the ContentServiceProvider class. Finally, I tidied things up a little by adding some helper functions to test whether the publishedAtField functionality is enabled in the class.

`composer require soda-framework/cms:dev-ryzr-patch-1`